### PR TITLE
Swap resize and rotate transformation order

### DIFF
--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/ImageAssetOnDemandVariantTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/ImageAssetOnDemandVariantTest.kt
@@ -20,6 +20,7 @@ import io.konifer.domain.image.vipsProperties
 import io.konifer.infrastructure.vips.ImageColorSpaceExtractor
 import io.konifer.infrastructure.vips.VipsOptionNames
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_BANDS
+import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_ORIENTATION
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_QUALITY
 import io.konifer.infrastructure.vips.transformer.ColorFilter
 import io.konifer.matchers.shouldBeApproximately
@@ -52,6 +53,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import javax.imageio.ImageIO
 import kotlin.math.min
+import kotlin.math.roundToInt
 
 class ImageAssetOnDemandVariantTest : BaseFunctionalTest() {
     @Test
@@ -342,6 +344,41 @@ class ImageAssetOnDemandVariantTest : BaseFunctionalTest() {
                 val expectedImage = ImageIO.read(ByteArrayInputStream(expectedStream.toByteArray()))
 
                 actualImage shouldHaveSamePixelContentAs expectedImage
+            }
+        }
+
+    @Test
+    fun `auto rotate derives missing height from oriented dimensions`() =
+        testInMemory {
+            val source = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.jpeg")!!.readBytes()
+            val image =
+                ByteArrayOutputStream().use { output ->
+                    Vips.run { arena ->
+                        VImage
+                            .newFromBytes(arena, source)
+                            .set(OPTION_ORIENTATION, 6)
+                            .writeToTestStream(arena, output, ImageFormat.JPEG)
+                    }
+                    output.toByteArray()
+                }
+            val sourceImage = byteArrayToImage(image)
+            val requestedWidth = 300
+            val expectedHeight = ((sourceImage.width.toDouble() * requestedWidth) / sourceImage.height).roundToInt()
+
+            storeAssetMultipartSource(client, image, StoreAssetRequest(alt = "an image"))
+
+            repeat(2) { requestIndex ->
+                val result =
+                    fetchAssetContent(
+                        client,
+                        width = requestedWidth,
+                        rotate = "auto",
+                        expectCacheHit = requestIndex == 1,
+                    ).second!!
+                val variantImage = byteArrayToImage(result)
+
+                variantImage.width shouldBe requestedWidth
+                variantImage.height shouldBe expectedHeight
             }
         }
 

--- a/service/src/main/kotlin/io/konifer/domain/transformation/TransformationDimensionNormalizer.kt
+++ b/service/src/main/kotlin/io/konifer/domain/transformation/TransformationDimensionNormalizer.kt
@@ -1,0 +1,59 @@
+package io.konifer.domain.transformation
+
+import io.konifer.common.image.Fit
+import io.konifer.common.image.Rotate
+import io.konifer.domain.context.RequestedTransformation
+import io.konifer.domain.variant.Attributes
+import kotlinx.coroutines.Deferred
+import kotlin.math.roundToInt
+
+object TransformationDimensionNormalizer {
+    suspend fun normalizeDimensions(
+        requested: RequestedTransformation,
+        normalizedRotate: Rotate,
+        originalAttributesDeferred: Deferred<Attributes>,
+    ): Pair<Int, Int> =
+        when (requested.fit) {
+            Fit.FIT -> {
+                if (requested.width == null || requested.height == null) {
+                    val originalVariant = originalAttributesDeferred.await()
+
+                    // Requested dimensions describe the oriented output, not the source before rotation.
+                    val (orientedWidth, orientedHeight) =
+                        orientHeightAndWidth(
+                            originalVariantAttributes = originalVariant,
+                            normalizedRotate = normalizedRotate,
+                        )
+
+                    when {
+                        requested.width != null ->
+                            Pair(
+                                requested.width,
+                                ((orientedHeight * requested.width) / orientedWidth).roundToInt(),
+                            )
+                        requested.height != null ->
+                            Pair(
+                                ((orientedWidth * requested.height) / orientedHeight).roundToInt(),
+                                requested.height,
+                            )
+                        else -> Pair(orientedWidth.roundToInt(), orientedHeight.roundToInt())
+                    }
+                } else {
+                    Pair(requested.width, requested.height)
+                }
+            }
+            Fit.FILL, Fit.STRETCH, Fit.CROP -> {
+                Pair(requireNotNull(requested.width), requireNotNull(requested.height))
+            }
+        }
+
+    private fun orientHeightAndWidth(
+        normalizedRotate: Rotate,
+        originalVariantAttributes: Attributes,
+    ): Pair<Double, Double> =
+        if (normalizedRotate == Rotate.NINETY || normalizedRotate == Rotate.TWO_HUNDRED_SEVENTY) {
+            Pair(originalVariantAttributes.height.toDouble(), originalVariantAttributes.width.toDouble())
+        } else {
+            Pair(originalVariantAttributes.width.toDouble(), originalVariantAttributes.height.toDouble())
+        }
+}

--- a/service/src/main/kotlin/io/konifer/domain/transformation/TransformationNormalizer.kt
+++ b/service/src/main/kotlin/io/konifer/domain/transformation/TransformationNormalizer.kt
@@ -1,7 +1,6 @@
 package io.konifer.domain.transformation
 
 import io.konifer.common.image.Filter
-import io.konifer.common.image.Fit
 import io.konifer.common.image.Flip
 import io.konifer.common.image.ImageFormat
 import io.konifer.common.image.ManipulationParameters
@@ -24,7 +23,6 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlin.math.min
-import kotlin.math.roundToInt
 
 class TransformationNormalizer(
     private val assetRepository: AssetRepository,
@@ -108,8 +106,8 @@ class TransformationNormalizer(
         if (requested.originalVariant) {
             return Transformation.ORIGINAL_VARIANT
         }
-        val (width, height) = normalizeDimensions(requested, originalAttributesDeferred)
         val (rotate, horizontalFlip) = normalizeRotateFlip(requested, originalAttributesDeferred)
+        val (width, height) = TransformationDimensionNormalizer.normalizeDimensions(requested, rotate, originalAttributesDeferred)
         val format = normalizeFormat(requested, originalAttributesDeferred)
         return Transformation(
             width = width,
@@ -139,36 +137,6 @@ class TransformationNormalizer(
             logger.debug { "Normalized requested transformation: $requested to: $it" }
         }
     }
-
-    private suspend fun normalizeDimensions(
-        requested: RequestedTransformation,
-        originalAttributesDeferred: Deferred<Attributes>,
-    ): Pair<Int, Int> =
-        when (requested.fit) {
-            Fit.FIT -> {
-                if ((requested.width == null && requested.height != null) || (requested.width != null && requested.height == null)) {
-                    val originalVariant = originalAttributesDeferred.await()
-
-                    val originalWidth = originalVariant.width.toDouble()
-                    val originalHeight = originalVariant.height.toDouble()
-                    // Derive height/width if needed
-                    Pair(
-                        requested.width ?: ((originalWidth * requireNotNull(requested.height)) / originalHeight).roundToInt(),
-                        requested.height ?: ((originalHeight * requireNotNull(requested.width)) / originalWidth).roundToInt(),
-                    )
-                } else if (requested.height != null && requested.width != null) {
-                    Pair(requested.width, requested.height)
-                } else {
-                    Pair(
-                        originalAttributesDeferred.await().width,
-                        originalAttributesDeferred.await().height,
-                    )
-                }
-            }
-            Fit.FILL, Fit.STRETCH, Fit.CROP -> {
-                Pair(requireNotNull(requested.width), requireNotNull(requested.height))
-            }
-        }
 
     private suspend fun normalizeFormat(
         requested: RequestedTransformation,

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/pipeline/VipsPipelines.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/pipeline/VipsPipelines.kt
@@ -21,9 +21,9 @@ object VipsPipelines {
 
     val preProcessingPipeline =
         vipsPipeline {
-            // Structural reduction
-            add(Resize)
+            // Spatial transformations
             add(RotateFlip)
+            add(Resize)
 
             // Color standardization
             add(TransformColorSpace)

--- a/service/src/test/kotlin/io/konifer/domain/transformation/TransformationNormalizerTest.kt
+++ b/service/src/test/kotlin/io/konifer/domain/transformation/TransformationNormalizerTest.kt
@@ -380,6 +380,98 @@ class TransformationNormalizerTest : BaseUnitTest() {
 
     @Nested
     inner class NormalizeResizeAttributesTests {
+        @ParameterizedTest
+        @EnumSource(Rotate::class, names = ["NINETY", "TWO_HUNDRED_SEVENTY"])
+        fun `width derives height from dimensions after a quarter turn rotation`(rotate: Rotate) =
+            runTest {
+                val asset = storePersistedAsset(width = 1200, height = 800)
+                val requested =
+                    createRequestedImageTransformation(
+                        width = 300,
+                        format = ImageFormat.PNG,
+                        fit = Fit.FIT,
+                        rotate = rotate,
+                    )
+
+                val normalized =
+                    transformationNormalizer.normalize(
+                        treePath = asset.path,
+                        entryId = asset.entryId,
+                        requested = requested,
+                    )
+
+                normalized.width shouldBe 300
+                normalized.height shouldBe 450
+            }
+
+        @Test
+        fun `height derives width from dimensions after a quarter turn rotation`() =
+            runTest {
+                val asset = storePersistedAsset(width = 1200, height = 800)
+                val requested =
+                    createRequestedImageTransformation(
+                        height = 300,
+                        format = ImageFormat.PNG,
+                        fit = Fit.FIT,
+                        rotate = Rotate.TWO_HUNDRED_SEVENTY,
+                    )
+
+                val normalized =
+                    transformationNormalizer.normalize(
+                        treePath = asset.path,
+                        entryId = asset.entryId,
+                        requested = requested,
+                    )
+
+                normalized.width shouldBe 200
+                normalized.height shouldBe 300
+            }
+
+        @Test
+        fun `rotation-only request uses oriented dimensions`() =
+            runTest {
+                val asset = storePersistedAsset(width = 1200, height = 800)
+                val requested =
+                    createRequestedImageTransformation(
+                        format = ImageFormat.PNG,
+                        fit = Fit.FIT,
+                        rotate = Rotate.NINETY,
+                    )
+
+                val normalized =
+                    transformationNormalizer.normalize(
+                        treePath = asset.path,
+                        entryId = asset.entryId,
+                        requested = requested,
+                    )
+
+                normalized.width shouldBe 800
+                normalized.height shouldBe 1200
+            }
+
+        @Test
+        fun `auto rotation derives dimensions from the resolved orientation`() =
+            runTest {
+                val asset = storePersistedAsset(width = 1200, height = 800, orientation = 6)
+                val requested =
+                    createRequestedImageTransformation(
+                        width = 300,
+                        format = ImageFormat.PNG,
+                        fit = Fit.FIT,
+                        rotate = Rotate.AUTO,
+                    )
+
+                val normalized =
+                    transformationNormalizer.normalize(
+                        treePath = asset.path,
+                        entryId = asset.entryId,
+                        requested = requested,
+                    )
+
+                normalized.width shouldBe 300
+                normalized.height shouldBe 450
+            }
+
         @Test
         fun `only height is required when using scale fit`() =
             runTest {

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/processor/VipsImageProcessorTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/processor/VipsImageProcessorTest.kt
@@ -6,6 +6,7 @@ import com.vanniktech.blurhash.BlurHash
 import io.konifer.ImageFactory
 import io.konifer.common.image.Fit
 import io.konifer.common.image.ImageFormat
+import io.konifer.common.image.Rotate
 import io.konifer.domain.asset.AssetDataContainer
 import io.konifer.domain.image.ColorSpace
 import io.konifer.domain.image.LQIPImplementation
@@ -38,6 +39,39 @@ class VipsImageProcessorTest {
 
     @Nested
     inner class PreProcessTests {
+        @ParameterizedTest
+        @EnumSource(Rotate::class, names = ["NINETY", "TWO_HUNDRED_SEVENTY"])
+        fun `rotation is applied before resize so requested dimensions describe the output`(rotate: Rotate) =
+            runTest {
+                val image = ImageFactory.testImage()
+                val transformationDataContainer =
+                    TransformationDataContainer(
+                        transformation =
+                            Transformation(
+                                width = 300,
+                                height = 200,
+                                fit = Fit.STRETCH,
+                                rotate = rotate,
+                                format = ImageFormat.JPEG,
+                                colorSpace = ColorSpace.SRGB,
+                            ),
+                    )
+
+                Vips.run { arena ->
+                    vipsImageProcessor.preprocess(
+                        arena = arena,
+                        source = VImage.newFromBytes(arena, image.bytes),
+                        sourceFormat = ImageFormat.JPEG,
+                        lqipImplementations = emptySet(),
+                        transformationDataContainer = transformationDataContainer,
+                    ) shouldBe PreprocessOutput.SourceTransformed
+                }
+
+                val attributes = transformationDataContainer.attributes.await()
+                attributes.width shouldBe 300
+                attributes.height shouldBe 200
+            }
+
         @Test
         fun `image is not preprocessed if not enabled`() =
             runTest {


### PR DESCRIPTION
This was causing height and width to be inverted for quarter turn rotational transformations (including `AUTO` rotation)