### PR TITLE
Better design for handling sequential pixel access when transforming images

### DIFF
--- a/service/src/functionalTest/kotlin/io/konifer/image/ImagePreviewTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/image/ImagePreviewTest.kt
@@ -4,6 +4,8 @@ import io.konifer.BaseFunctionalTest
 import io.konifer.byteArrayToImage
 import io.konifer.common.http.StoreAssetRequest
 import io.konifer.domain.image.LQIPImplementation
+import io.konifer.infrastructure.http.APP_LQIP_BLURHASH
+import io.konifer.infrastructure.http.APP_LQIP_THUMBHASH
 import io.konifer.testInMemory
 import io.konifer.util.fetchAssetContent
 import io.konifer.util.fetchAssetInfo
@@ -187,6 +189,87 @@ class ImagePreviewTest : BaseFunctionalTest() {
 
             result.lqip.blurhash shouldBe original.lqip.blurhash
             result.lqip.thumbhash shouldBe original.lqip.thumbhash
+        }
+
+    @Test
+    fun `lqips are regenerated without corrupting the transformed variant`() =
+        testInMemory(
+            """
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
+                }
+              }
+            }
+            """.trimIndent(),
+        ) {
+            val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
+            val originalImage = byteArrayToImage(image)
+            val originalLqip =
+                storeAssetMultipartSource(client, image, StoreAssetRequest(), path = PATH)
+                    .second!!
+                    .variants
+                    .single()
+                    .lqip
+
+            val (response, variantBytes) =
+                fetchAssetContent(
+                    client,
+                    path = PATH,
+                    filter = "sepia",
+                    expectCacheHit = false,
+                )
+
+            val variantImage = byteArrayToImage(variantBytes!!)
+            variantImage.width shouldBe originalImage.width
+            variantImage.height shouldBe originalImage.height
+            variantImage.getRGB(variantImage.width / 2, variantImage.height / 2) shouldNotBe
+                originalImage.getRGB(originalImage.width / 2, originalImage.height / 2)
+
+            response.headers[APP_LQIP_BLURHASH] shouldNotBe null
+            response.headers[APP_LQIP_THUMBHASH] shouldNotBe null
+            response.headers[APP_LQIP_BLURHASH] shouldNotBe originalLqip.blurhash
+            response.headers[APP_LQIP_THUMBHASH] shouldNotBe originalLqip.thumbhash
+        }
+
+    @Test
+    fun `lqips are generated without corrupting preprocessed content`() =
+        testInMemory(
+            """
+            paths {
+              "/**" {
+                image {
+                  lqip = [ "thumbhash", "blurhash" ]
+                }
+                transform {
+                  preprocessing {
+                    enabled = true
+                    image {
+                      filter = sepia
+                    }
+                  }
+                }
+              }
+            }
+            """.trimIndent(),
+        ) {
+            val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
+            val originalImage = byteArrayToImage(image)
+            val stored = storeAssetMultipartSource(client, image, StoreAssetRequest(), path = PATH).second!!
+            val storedLqip = stored.variants.single().lqip
+
+            storedLqip.blurhash shouldNotBe null
+            storedLqip.thumbhash shouldNotBe null
+
+            val (response, preprocessedBytes) = fetchAssetContent(client, path = PATH, expectCacheHit = true)
+            val preprocessedImage = byteArrayToImage(preprocessedBytes!!)
+            preprocessedImage.width shouldBe originalImage.width
+            preprocessedImage.height shouldBe originalImage.height
+            preprocessedImage.getRGB(preprocessedImage.width / 2, preprocessedImage.height / 2) shouldNotBe
+                originalImage.getRGB(originalImage.width / 2, originalImage.height / 2)
+            response.headers[APP_LQIP_BLURHASH] shouldBe storedLqip.blurhash
+            response.headers[APP_LQIP_THUMBHASH] shouldBe storedLqip.thumbhash
         }
 
     private suspend fun storeAndAssert(

--- a/service/src/main/java/app/photofox/vipsffm/VipsImageCopyMemory.java
+++ b/service/src/main/java/app/photofox/vipsffm/VipsImageCopyMemory.java
@@ -1,0 +1,64 @@
+package app.photofox.vipsffm;
+
+import app.photofox.vipsffm.jextract.VipsRaw;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.util.Objects;
+
+/**
+ * Temporary binding for {@code vips_image_copy_memory()} until vips-ffm exposes it.
+ */
+public final class VipsImageCopyMemory {
+    private static final String OPERATION_NAME = "vips_image_copy_memory";
+    private static final Arena LIBRARY_ARENA = Arena.ofAuto();
+    private static final MethodHandle COPY_MEMORY = copyMemoryHandle();
+
+    private VipsImageCopyMemory() {
+    }
+
+    /**
+     * Renders {@code source} to memory and returns a memory-backed image. Libvips may return
+     * another reference to {@code source} when it is already backed by a simple memory buffer.
+     *
+     * <p>The returned image and its native memory are owned by {@code arena}.</p>
+     */
+    public static VImage copyMemory(Arena arena, VImage source) throws VipsError {
+        Objects.requireNonNull(arena, "arena");
+        Objects.requireNonNull(source, "source");
+
+        var sourceAddress = source.getUnsafeStructAddress();
+        if (!VipsValidation.isValidPointer(sourceAddress)) {
+            VipsValidation.throwInvalidInputError(OPERATION_NAME, "image");
+        }
+
+        MemorySegment result;
+        try {
+            result = (MemorySegment) COPY_MEMORY.invokeExact(sourceAddress);
+        } catch (Throwable cause) {
+            throw new AssertionError("Unexpected failure calling " + OPERATION_NAME, cause);
+        }
+
+        if (!VipsValidation.isValidPointer(result)) {
+            VipsValidation.throwInvalidOutputError(OPERATION_NAME, "result");
+        }
+
+        var arenaScopedResult = result.reinterpret(arena, VipsRaw::g_object_unref);
+        return new VImage(arena, arenaScopedResult);
+    }
+
+    private static MethodHandle copyMemoryHandle() {
+        var symbolLookup = VipsLibLookup.buildSymbolLoader(LIBRARY_ARENA)
+            .or(SymbolLookup.loaderLookup())
+            .or(Linker.nativeLinker().defaultLookup());
+        var address = symbolLookup.find(OPERATION_NAME)
+            .orElseThrow(() -> new UnsatisfiedLinkError("unresolved symbol: " + OPERATION_NAME));
+        var descriptor = FunctionDescriptor.of(VipsRaw.C_POINTER, VipsRaw.C_POINTER);
+
+        return Linker.nativeLinker().downcallHandle(address, descriptor);
+    }
+}

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/VipsUtils.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/VipsUtils.kt
@@ -5,7 +5,10 @@ import app.photofox.vipsffm.enums.VipsAccess
 import io.konifer.common.image.ImageFormat
 import io.konifer.domain.image.vipsProperties
 
-val noOptions = emptyArray<VipsOption>()
+val defaultOptions: Array<VipsOption> =
+    arrayOf(
+        VipsOption.Enum(VipsOptionNames.OPTION_ACCESS, VipsAccess.ACCESS_SEQUENTIAL),
+    )
 
 val supportsPagingOptions: Array<VipsOption> =
     arrayOf(
@@ -33,5 +36,5 @@ fun createDecoderOptions(
     if (sourceFormat.vipsProperties.supportsPaging) {
         return noPagingOptions
     }
-    return noOptions
+    return defaultOptions
 }

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/decode/VipsThumbnailDecoder.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/decode/VipsThumbnailDecoder.kt
@@ -15,6 +15,7 @@ import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_SIZE
 import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.toVipsInteresting
 import io.konifer.infrastructure.vips.transformer.AutoRotate
+import io.konifer.infrastructure.vips.transformer.PixelAccess
 import io.konifer.infrastructure.vips.transformer.Resize
 import io.konifer.infrastructure.vips.transformer.ResizePlan
 import java.lang.foreign.Arena
@@ -150,6 +151,7 @@ data class DecodedVipsImage(
     val image: VImage,
     val appliedTransformations: List<AppliedTransformation> = emptyList(),
     val requiresLqipRegeneration: Boolean = false,
+    val pixelAccess: PixelAccess = PixelAccess.SEQUENTIAL,
 ) {
     fun copy(): DecodedVipsImage = copy(image = image.copy())
 }

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/pipeline/VipsPipeline.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/pipeline/VipsPipeline.kt
@@ -1,10 +1,14 @@
 package io.konifer.infrastructure.vips.pipeline
 
 import app.photofox.vipsffm.VImage
+import app.photofox.vipsffm.VipsImageCopyMemory
 import io.konifer.domain.variant.Transformation
 import io.konifer.infrastructure.vips.decode.DecodedVipsImage
 import io.konifer.infrastructure.vips.premultiplyIfNecessary
-import io.konifer.infrastructure.vips.transformer.AlphaState
+import io.konifer.infrastructure.vips.transformer.AlphaRequirement
+import io.konifer.infrastructure.vips.transformer.PixelAccess
+import io.konifer.infrastructure.vips.transformer.TransformationContext
+import io.konifer.infrastructure.vips.transformer.TransformationDecision
 import io.konifer.infrastructure.vips.transformer.VipsTransformer
 import io.konifer.infrastructure.vips.unPremultiplyIfNecessary
 import io.ktor.util.logging.KtorSimpleLogger
@@ -38,6 +42,8 @@ class VipsPipeline(
                 .map { it.name }
                 .toSet()
         var isAlphaPremultiplied = false
+        var currentPixelAccess = source.pixelAccess
+
         var requiresLqipRegeneration = source.requiresLqipRegeneration
         var processed = VipsTransformationResult.new(source.image)
         var failed = false
@@ -48,19 +54,27 @@ class VipsPipeline(
             if (failed) {
                 break
             }
-            if (transformer.requiresTransformation(
-                    arena = arena,
-                    source = processed.processed,
-                    transformation = transformation,
-                    appliedTransformations = appliedTransformations,
+            val decision =
+                transformer.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = processed.processed,
+                        transformation = transformation,
+                        appliedTransformations = appliedTransformations,
+                    ),
                 )
-            ) {
+            if (decision is TransformationDecision.Apply) {
                 val source =
                     prepareForNextTransformation(
-                        transformer = transformer,
+                        arena = arena,
                         processed = processed.processed,
                         isAlphaPremultiplied = isAlphaPremultiplied,
-                    ).also { isAlphaPremultiplied = it.second }.first
+                        decision = decision,
+                        pixelAccess = currentPixelAccess,
+                    ).also {
+                        isAlphaPremultiplied = it.isAlphaPremultiplied
+                        currentPixelAccess = it.currentPixelAccess
+                    }.processed
 
                 try {
                     processed =
@@ -70,14 +84,10 @@ class VipsPipeline(
                             transformation = transformation,
                         )
                     appliedTransformations.add(
-                        AppliedTransformation(
-                            name = transformer.name,
-                            exceptionMessage = null,
-                        ),
+                        AppliedTransformation.success(transformer.name),
                     )
                     requiresLqipRegeneration = requiresLqipRegeneration || processed.requiresLqipRegeneration
                 } catch (e: Exception) {
-                    logger.error("Vips pipeline failed! Pipeline results: $appliedTransformations", e)
                     failed = true
                     appliedTransformations.add(
                         AppliedTransformation(
@@ -85,6 +95,7 @@ class VipsPipeline(
                             exceptionMessage = e.message,
                         ),
                     )
+                    logger.error("Vips pipeline failed! Pipeline results: $appliedTransformations", e)
                 }
             }
         }
@@ -98,32 +109,54 @@ class VipsPipeline(
             processed = processed.processed.unPremultiplyIfNecessary(isAlphaPremultiplied),
             requiresLqipRegeneration = requiresLqipRegeneration,
             appliedTransformations = appliedTransformations,
+            processedPixelAccess = currentPixelAccess,
         )
     }
 
     private fun prepareForNextTransformation(
-        transformer: VipsTransformer,
+        arena: Arena,
         processed: VImage,
         isAlphaPremultiplied: Boolean,
-    ): Pair<VImage, Boolean> {
+        pixelAccess: PixelAccess,
+        decision: TransformationDecision.Apply,
+    ): PipelineState {
         var newAlphaState = isAlphaPremultiplied
-        return when (transformer.requiresAlphaState) {
-            AlphaState.PREMULTIPLIED -> {
-                processed.premultiplyIfNecessary(isAlphaPremultiplied).let {
-                    newAlphaState = it.second
-                    it.first
+        val alphaPrepared =
+            when (decision.requiredAlpha) {
+                AlphaRequirement.PREMULTIPLIED -> {
+                    processed.premultiplyIfNecessary(isAlphaPremultiplied).let {
+                        newAlphaState = it.second
+                        it.first
+                    }
                 }
-            }
-            AlphaState.UN_PREMULTIPLIED -> {
-                processed.unPremultiplyIfNecessary(isAlphaPremultiplied).also {
-                    newAlphaState = false
+                AlphaRequirement.UN_PREMULTIPLIED -> {
+                    processed.unPremultiplyIfNecessary(isAlphaPremultiplied).also {
+                        newAlphaState = false
+                    }
                 }
+                AlphaRequirement.EITHER -> processed
             }
-            AlphaState.EITHER -> processed
-        }.let {
-            Pair(it, newAlphaState)
-        }
+        val requiresRandomAccess =
+            pixelAccess == PixelAccess.SEQUENTIAL && decision.requiredPixelAccess == PixelAccess.RANDOM
+        val preparedSource =
+            if (requiresRandomAccess) {
+                VipsImageCopyMemory.copyMemory(arena, alphaPrepared)
+            } else {
+                alphaPrepared
+            }
+
+        return PipelineState(
+            isAlphaPremultiplied = newAlphaState,
+            processed = preparedSource,
+            currentPixelAccess = if (requiresRandomAccess) PixelAccess.RANDOM else pixelAccess,
+        )
     }
+
+    private data class PipelineState(
+        val processed: VImage,
+        val isAlphaPremultiplied: Boolean,
+        val currentPixelAccess: PixelAccess,
+    )
 }
 
 fun vipsPipeline(initializer: VipsPipelineBuilder.() -> Unit): VipsPipelineBuilder = VipsPipelineBuilder().apply(initializer)
@@ -149,12 +182,21 @@ data class VipsPipelineResult(
     val processed: VImage,
     val requiresLqipRegeneration: Boolean,
     val appliedTransformations: List<AppliedTransformation>,
+    val processedPixelAccess: PixelAccess,
 )
 
 data class AppliedTransformation(
     val name: String,
     val exceptionMessage: String?,
 ) {
+    companion object Factory {
+        fun success(name: String): AppliedTransformation =
+            AppliedTransformation(
+                name = name,
+                exceptionMessage = null,
+            )
+    }
+
     override fun toString(): String =
         if (exceptionMessage == null) {
             "Successfully applied transformation $name"

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/processor/VipsImageProcessor.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/processor/VipsImageProcessor.kt
@@ -2,7 +2,7 @@ package io.konifer.infrastructure.vips.processor
 
 import app.photofox.vipsffm.VImage
 import app.photofox.vipsffm.Vips
-import app.photofox.vipsffm.VipsOption
+import app.photofox.vipsffm.VipsImageCopyMemory
 import io.konifer.common.image.Fit
 import io.konifer.common.image.Gravity
 import io.konifer.common.image.ImageFormat
@@ -15,11 +15,12 @@ import io.konifer.domain.variant.LQIPs
 import io.konifer.domain.variant.Transformation
 import io.konifer.infrastructure.vips.ImagePreviewGenerator
 import io.konifer.infrastructure.vips.VipsEncoder
-import io.konifer.infrastructure.vips.createDecoderOptions
 import io.konifer.infrastructure.vips.decode.DecodedVipsImage
+import io.konifer.infrastructure.vips.decode.VipsThumbnailDecoder
 import io.konifer.infrastructure.vips.pipeline.VipsPipelines.lqipVariantPipeline
 import io.konifer.infrastructure.vips.pipeline.VipsPipelines.preProcessingPipeline
 import io.konifer.infrastructure.vips.pipeline.VipsPipelines.variantGenerationPipeline
+import io.konifer.infrastructure.vips.transformer.PixelAccess
 import io.ktor.util.logging.KtorSimpleLogger
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
@@ -28,7 +29,6 @@ import java.io.ByteArrayOutputStream
 import java.lang.foreign.Arena
 import java.nio.file.Path
 import kotlin.io.path.extension
-import kotlin.io.path.pathString
 
 class VipsImageProcessor {
     private val logger = KtorSimpleLogger(this::class.qualifiedName!!)
@@ -70,30 +70,41 @@ class VipsImageProcessor {
                 source = source,
                 transformation = transformation,
             )
+        val shouldEncode = preProcessed.appliedTransformations.isNotEmpty() || sourceFormat != transformation.format
+        val shouldGeneratePreview = lqipImplementations.isNotEmpty()
+        val outputSource =
+            if (shouldEncode && shouldGeneratePreview) {
+                when (preProcessed.processedPixelAccess) {
+                    PixelAccess.RANDOM -> preProcessed.processed.copy()
+                    PixelAccess.SEQUENTIAL -> VipsImageCopyMemory.copyMemory(arena, preProcessed.processed)
+                }
+            } else {
+                preProcessed.processed
+            }
 
         transformationDataContainer.attributes.complete(
             Attributes.createAttributes(
-                image = preProcessed.processed,
+                image = outputSource,
                 sourceFormat = sourceFormat,
                 destinationFormat = transformation.format,
             ),
         )
         // we always want to generate lqips if configured when preprocessing even if the pipeline
         // says we don't need to
-        if (lqipImplementations.isNotEmpty()) {
+        if (shouldGeneratePreview) {
             generatePreviewVariant(
                 arena = arena,
-                sourceImage = preProcessed.processed,
+                sourceImage = outputSource,
                 lqipImplementations = lqipImplementations,
                 deferred = transformationDataContainer.lqips,
             )
         } else {
             transformationDataContainer.lqips.complete(null)
         }
-        return if (preProcessed.appliedTransformations.isNotEmpty() || sourceFormat != transformation.format) {
+        return if (shouldEncode) {
             VipsEncoder.writeToStream(
                 arena = arena,
-                source = preProcessed.processed,
+                source = outputSource,
                 format = transformation.format,
                 quality = transformation.quality,
                 outputChannel = transformationDataContainer.output,
@@ -112,49 +123,58 @@ class VipsImageProcessor {
         lqipImplementations: Set<LQIPImplementation>,
     ) = withContext(Dispatchers.IO) {
         Vips.run { arena ->
-            // Some transformations may want all pages, if present
-            val sourceByDecoderOptions = mutableMapOf<Array<VipsOption>, VImage>()
             val sourceFormat = ImageFormat.fromExtension(".${sourceFile.extension}")
             for ((transformation, output, lqips, attributes) in transformationDataContainers) {
-                val decoderOptions =
-                    createDecoderOptions(
-                        sourceFormat = sourceFormat,
-                        destinationFormat = transformation.format,
+                runCatching {
+                    val source =
+                        VipsThumbnailDecoder.decode(
+                            arena = arena,
+                            transformation = transformation,
+                            sourceFormat = sourceFormat,
+                            sourceFile = sourceFile,
+                        )
+
+                    val variantResult = variantGenerationPipeline.run(arena, source, transformation)
+                    val shouldGeneratePreview =
+                        variantResult.requiresLqipRegeneration && lqipImplementations.isNotEmpty()
+                    val outputSource =
+                        if (shouldGeneratePreview) {
+                            when (variantResult.processedPixelAccess) {
+                                PixelAccess.RANDOM -> variantResult.processed.copy()
+                                PixelAccess.SEQUENTIAL -> VipsImageCopyMemory.copyMemory(arena, variantResult.processed)
+                            }
+                        } else {
+                            variantResult.processed
+                        }
+
+                    if (shouldGeneratePreview) {
+                        generatePreviewVariant(
+                            arena = arena,
+                            sourceImage = outputSource,
+                            lqipImplementations = lqipImplementations,
+                            deferred = lqips,
+                        )
+                    } else {
+                        lqips.complete(null)
+                    }
+                    attributes.complete(
+                        Attributes.createAttributes(
+                            image = outputSource,
+                            sourceFormat = sourceFormat,
+                            destinationFormat = transformation.format,
+                        ),
                     )
-                val image =
-                    sourceByDecoderOptions
-                        .getOrPut(decoderOptions) {
-                            VImage.newFromFile(arena, sourceFile.pathString, *decoderOptions)
-                        }.copy()
 
-                val source = DecodedVipsImage(image = image)
-                val variantResult = variantGenerationPipeline.run(arena, source, transformation)
-
-                if (variantResult.requiresLqipRegeneration && lqipImplementations.isNotEmpty()) {
-                    generatePreviewVariant(
+                    VipsEncoder.writeToStream(
                         arena = arena,
-                        sourceImage = variantResult.processed,
-                        lqipImplementations = lqipImplementations,
-                        deferred = lqips,
+                        source = outputSource,
+                        format = transformation.format,
+                        quality = transformation.quality,
+                        outputChannel = output,
                     )
-                } else {
-                    lqips.complete(null)
-                }
-                attributes.complete(
-                    Attributes.createAttributes(
-                        image = variantResult.processed,
-                        sourceFormat = sourceFormat,
-                        destinationFormat = transformation.format,
-                    ),
-                )
-
-                VipsEncoder.writeToStream(
-                    arena = arena,
-                    source = variantResult.processed,
-                    format = transformation.format,
-                    quality = transformation.quality,
-                    outputChannel = output,
-                )
+                }.onFailure {
+                    output.cancel(it)
+                }.getOrThrow()
             }
         }
     }

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/AutoRotate.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/AutoRotate.kt
@@ -3,13 +3,11 @@ package io.konifer.infrastructure.vips.transformer
 import app.photofox.vipsffm.VImage
 import io.konifer.common.image.Rotate
 import io.konifer.domain.variant.Transformation
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import java.lang.foreign.Arena
 
 object AutoRotate : VipsTransformer {
     override val name: String = "AutoRotate"
-    override val requiresAlphaState: AlphaState = AlphaState.EITHER
 
     override fun transform(
         arena: Arena,
@@ -21,12 +19,20 @@ object AutoRotate : VipsTransformer {
             requiresLqipRegeneration = changesImageOrientation(transformation),
         )
 
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean = transformation.isAutoRotate
+    override fun decide(context: TransformationContext): TransformationDecision =
+        if (context.transformation.isAutoRotate) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.EITHER,
+                requiredPixelAccess =
+                    if (context.transformation.rotate == Rotate.ZERO) {
+                        PixelAccess.SEQUENTIAL
+                    } else {
+                        PixelAccess.RANDOM
+                    },
+            )
+        } else {
+            TransformationDecision.Skip
+        }
 
     /**
      * Auto-rotation always normalizes orientation metadata, but only invalidates image-derived

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/ColorFilter.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/ColorFilter.kt
@@ -10,7 +10,6 @@ import io.konifer.common.image.Filter
 import io.konifer.domain.variant.Transformation
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_BANDS
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_N
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import java.lang.foreign.Arena
 
@@ -68,14 +67,16 @@ object ColorFilter : VipsTransformer {
     val blackWhiteThreshold = listOf(128.0)
 
     override val name: String = "ColorFilter"
-    override val requiresAlphaState: AlphaState = AlphaState.UN_PREMULTIPLIED
 
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean = transformation.filter != Filter.NONE
+    override fun decide(context: TransformationContext): TransformationDecision =
+        if (context.transformation.filter != Filter.NONE) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
+        } else {
+            TransformationDecision.Skip
+        }
 
     override fun transform(
         arena: Arena,

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/CropFirstPage.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/CropFirstPage.kt
@@ -3,7 +3,6 @@ package io.konifer.infrastructure.vips.transformer
 import app.photofox.vipsffm.VImage
 import io.konifer.domain.variant.Transformation
 import io.konifer.infrastructure.vips.VipsOptionNames
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import java.lang.foreign.Arena
 
@@ -23,20 +22,16 @@ object CropFirstPage : VipsTransformer {
         )
     }
 
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean {
-        val nPages = source.getInt(VipsOptionNames.OPTION_N_PAGES) ?: 1
-        if (nPages == 1) {
-            return false
+    override fun decide(context: TransformationContext): TransformationDecision {
+        val pageCount = context.source.getInt(VipsOptionNames.OPTION_N_PAGES) ?: 1
+        val pageHeight = context.source.getInt(VipsOptionNames.OPTION_PAGE_HEIGHT) ?: context.source.height
+        return if (pageCount > 1 && context.source.height > pageHeight) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.EITHER,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
+        } else {
+            TransformationDecision.Skip
         }
-
-        val pageHeight = source.getInt(VipsOptionNames.OPTION_PAGE_HEIGHT) ?: source.height
-        return source.height > pageHeight
     }
-
-    override val requiresAlphaState: AlphaState = AlphaState.UN_PREMULTIPLIED
 }

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/ForceRgbBands.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/ForceRgbBands.kt
@@ -8,7 +8,6 @@ import io.konifer.domain.variant.Transformation
 import io.konifer.infrastructure.vips.ImageColorSpaceExtractor
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_BACKGROUND
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_BANDS
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import java.lang.foreign.Arena
 
@@ -44,16 +43,19 @@ object ForceRgbBands : VipsTransformer {
         )
     }
 
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean =
-        source.hasAlpha() ||
-            source.getInt(OPTION_BANDS) != EXPECTED_BANDS ||
-            ImageColorSpaceExtractor.extract(source) != ColorSpace.SRGB
-
-    override val requiresAlphaState: AlphaState = AlphaState.UN_PREMULTIPLIED
     override val name: String = "ForceRgbBands"
+
+    override fun decide(context: TransformationContext): TransformationDecision =
+        if (
+            context.source.hasAlpha() ||
+            context.source.getInt(OPTION_BANDS) != EXPECTED_BANDS ||
+            ImageColorSpaceExtractor.extract(context.source) != ColorSpace.SRGB
+        ) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
+        } else {
+            TransformationDecision.Skip
+        }
 }

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/GaussianBlur.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/GaussianBlur.kt
@@ -2,7 +2,6 @@ package io.konifer.infrastructure.vips.transformer
 
 import app.photofox.vipsffm.VImage
 import io.konifer.domain.variant.Transformation
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import java.lang.foreign.Arena
 
@@ -12,14 +11,16 @@ import java.lang.foreign.Arena
  */
 object GaussianBlur : VipsTransformer {
     override val name: String = "GaussianBlur"
-    override val requiresAlphaState: AlphaState = AlphaState.PREMULTIPLIED
 
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean = transformation.blur > 0
+    override fun decide(context: TransformationContext): TransformationDecision =
+        if (context.transformation.blur > 0) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.PREMULTIPLIED,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
+        } else {
+            TransformationDecision.Skip
+        }
 
     override fun transform(
         arena: Arena,

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/Pad.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/Pad.kt
@@ -10,7 +10,6 @@ import io.konifer.domain.variant.Transformation
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_BACKGROUND
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_BANDS
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_EXTEND
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import io.ktor.util.logging.KtorSimpleLogger
 import io.ktor.util.logging.debug
@@ -26,14 +25,18 @@ object Pad : VipsTransformer {
     private val logger = KtorSimpleLogger(this::class.qualifiedName!!)
 
     override val name: String = "Pad"
-    override val requiresAlphaState: AlphaState = AlphaState.UN_PREMULTIPLIED
 
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean = transformation.padding.amount > 0 && transformation.padding.color.isNotEmpty()
+    override fun decide(context: TransformationContext): TransformationDecision {
+        val padding = context.transformation.padding
+        return if (padding.amount > 0 && padding.color.isNotEmpty()) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
+        } else {
+            TransformationDecision.Skip
+        }
+    }
 
     override fun transform(
         arena: Arena,

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/Resize.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/Resize.kt
@@ -12,7 +12,6 @@ import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_INTERESTING
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_NO_ROTATE
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_SIZE
 import io.konifer.infrastructure.vips.pageSafeHeight
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import io.konifer.infrastructure.vips.toVipsInteresting
 import io.ktor.util.logging.KtorSimpleLogger
@@ -28,14 +27,23 @@ object Resize : VipsTransformer {
     private val logger = KtorSimpleLogger(this::class.qualifiedName!!)
 
     override val name: String = "Resize"
-    override val requiresAlphaState: AlphaState = AlphaState.UN_PREMULTIPLIED
 
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean = createPlan(source, transformation).requiresTransformation
+    override fun decide(context: TransformationContext): TransformationDecision =
+        if (createPlan(context.source, context.transformation).requiresTransformation) {
+            val pixelAccess =
+                if (context.transformation.fit == Fit.CROP) {
+                    PixelAccess.RANDOM
+                } else {
+                    PixelAccess.SEQUENTIAL
+                }
+
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                requiredPixelAccess = pixelAccess,
+            )
+        } else {
+            TransformationDecision.Skip
+        }
 
     fun createPlan(
         source: VImage,

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/RotateFlip.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/RotateFlip.kt
@@ -6,23 +6,31 @@ import app.photofox.vipsffm.enums.VipsDirection
 import io.konifer.common.image.Rotate
 import io.konifer.domain.variant.Transformation
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_ORIENTATION
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import java.lang.foreign.Arena
 
 object RotateFlip : VipsTransformer {
     override val name: String = "RotateFlip"
-    override val requiresAlphaState: AlphaState = AlphaState.EITHER
 
     /**
      * Required if the transformation has any rotation or specified that is not an auto-rotation
      */
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean = !transformation.isAutoRotate && (transformation.rotate != Rotate.ZERO || transformation.horizontalFlip)
+    override fun decide(context: TransformationContext): TransformationDecision {
+        val transformation = context.transformation
+        return if (!transformation.isAutoRotate && (transformation.rotate != Rotate.ZERO || transformation.horizontalFlip)) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.EITHER,
+                requiredPixelAccess =
+                    if (transformation.rotate == Rotate.ZERO) {
+                        PixelAccess.SEQUENTIAL
+                    } else {
+                        PixelAccess.RANDOM
+                    },
+            )
+        } else {
+            TransformationDecision.Skip
+        }
+    }
 
     override fun transform(
         arena: Arena,

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/StripMetadata.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/StripMetadata.kt
@@ -4,7 +4,6 @@ import app.photofox.vipsffm.VImage
 import io.konifer.common.image.MetadataType
 import io.konifer.domain.variant.MetadataTransformation
 import io.konifer.domain.variant.Transformation
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import java.lang.foreign.Arena
 
@@ -17,9 +16,17 @@ object StripMetadata : VipsTransformer {
     private const val IPTC_TAG = "iptc-data"
     private const val IFD1_TAG_NAME = "jpeg-thumbnail-data"
 
-    override val requiresAlphaState = AlphaState.EITHER
-
     override val name = "StripMetadata"
+
+    override fun decide(context: TransformationContext): TransformationDecision =
+        if (context.source.fields.any { shouldStrip(it, context.transformation.metadata) }) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.EITHER,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
+        } else {
+            TransformationDecision.Skip
+        }
 
     override fun transform(
         arena: Arena,
@@ -35,15 +42,6 @@ object StripMetadata : VipsTransformer {
             requiresLqipRegeneration = false,
         )
     }
-
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean =
-        source.fields
-            .any { shouldStrip(it, transformation.metadata) }
 
     private fun shouldStrip(
         field: String,

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/StripThumbnailExif.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/StripThumbnailExif.kt
@@ -2,7 +2,6 @@ package io.konifer.infrastructure.vips.transformer
 
 import app.photofox.vipsffm.VImage
 import io.konifer.domain.variant.Transformation
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import java.lang.foreign.Arena
 
@@ -15,7 +14,19 @@ object StripThumbnailExif : VipsTransformer {
     private const val THUMBNAIL_DATA_FIELD = "jpeg-thumbnail-data"
 
     override val name = "RemoveThumbnailExif"
-    override val requiresAlphaState = AlphaState.EITHER
+
+    override fun decide(context: TransformationContext): TransformationDecision =
+        if (
+            context.appliedTransformations.isNotEmpty() &&
+            !(context.appliedTransformations.size == 1 && context.appliedTransformations.first().name == StripMetadata.name)
+        ) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.EITHER,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
+        } else {
+            TransformationDecision.Skip
+        }
 
     override fun transform(
         arena: Arena,
@@ -34,16 +45,4 @@ object StripThumbnailExif : VipsTransformer {
             requiresLqipRegeneration = false,
         )
     }
-
-    /**
-     * Only run this transformation if any transformations have been applied to the image.
-     */
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean =
-        appliedTransformations.isNotEmpty() &&
-            !(appliedTransformations.size == 1 && appliedTransformations.first().name == StripMetadata.name)
 }

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/TransformColorSpace.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/TransformColorSpace.kt
@@ -9,7 +9,6 @@ import io.konifer.domain.variant.Transformation
 import io.konifer.infrastructure.vips.ImageColorSpaceExtractor
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_BLACK_POINT_COMPENSATION
 import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_INTENT
-import io.konifer.infrastructure.vips.pipeline.AppliedTransformation
 import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import io.konifer.infrastructure.vips.transformer.TransformColorSpace.ProfileNames.DISPLAY_P3
 import io.konifer.infrastructure.vips.transformer.TransformColorSpace.ProfileNames.GRAYSCALE
@@ -22,6 +21,18 @@ object TransformColorSpace : VipsTransformer {
         const val DISPLAY_P3 = "p3"
         const val GRAYSCALE = "bw"
     }
+
+    override val name = "TransformColorSpace"
+
+    override fun decide(context: TransformationContext): TransformationDecision =
+        if (ImageColorSpaceExtractor.extract(context.source) != context.transformation.colorSpace) {
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
+        } else {
+            TransformationDecision.Skip
+        }
 
     override fun transform(
         arena: Arena,
@@ -56,18 +67,4 @@ object TransformColorSpace : VipsTransformer {
             requiresLqipRegeneration = true,
         )
     }
-
-    override fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean {
-        val currentColorSpace = ImageColorSpaceExtractor.extract(source)
-
-        return currentColorSpace != transformation.colorSpace
-    }
-
-    override val requiresAlphaState = AlphaState.UN_PREMULTIPLIED
-    override val name = "TransformColorSpace"
 }

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/TransformationDecision.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/TransformationDecision.kt
@@ -1,0 +1,21 @@
+package io.konifer.infrastructure.vips.transformer
+
+sealed interface TransformationDecision {
+    data class Apply(
+        val requiredAlpha: AlphaRequirement,
+        val requiredPixelAccess: PixelAccess,
+    ) : TransformationDecision
+
+    object Skip : TransformationDecision
+}
+
+enum class AlphaRequirement {
+    PREMULTIPLIED,
+    UN_PREMULTIPLIED,
+    EITHER,
+}
+
+enum class PixelAccess {
+    SEQUENTIAL,
+    RANDOM,
+}

--- a/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/VipsTransformer.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/vips/transformer/VipsTransformer.kt
@@ -7,6 +7,14 @@ import io.konifer.infrastructure.vips.pipeline.VipsTransformationResult
 import java.lang.foreign.Arena
 
 interface VipsTransformer {
+    val name: String
+
+    /**
+     * Decides whether this transformer should run and, when it should, which image state it requires.
+     * Implementations should only inspect the request and image header; pixel evaluation belongs in [transform].
+     */
+    fun decide(context: TransformationContext): TransformationDecision
+
     /**
      * Add the transformation to the Vips transformation pipeline. Note that vips transformation is inherently
      * demand-driven and the actual transformation will not apply unless the image is written to an output
@@ -18,29 +26,11 @@ interface VipsTransformer {
         source: VImage,
         transformation: Transformation,
     ): VipsTransformationResult
-
-    /**
-     * Whether the image requires [transform] to be called on it. If false is returned, then the image does not
-     * need the implementing transformer applied to it.
-     */
-    fun requiresTransformation(
-        arena: Arena,
-        source: VImage,
-        transformation: Transformation,
-        appliedTransformations: List<AppliedTransformation>,
-    ): Boolean
-
-    /**
-     * What state does alpha need to be in before running this transformer. Implementations should
-     * assume that the image passed to [transform] will have alpha in the desired state.
-     */
-    val requiresAlphaState: AlphaState
-
-    val name: String
 }
 
-enum class AlphaState {
-    PREMULTIPLIED,
-    UN_PREMULTIPLIED,
-    EITHER,
-}
+data class TransformationContext(
+    val arena: Arena,
+    val source: VImage,
+    val transformation: Transformation,
+    val appliedTransformations: List<AppliedTransformation>,
+)

--- a/service/src/test/kotlin/app/photofox/vipsffm/VipsImageCopyMemoryTest.kt
+++ b/service/src/test/kotlin/app/photofox/vipsffm/VipsImageCopyMemoryTest.kt
@@ -1,0 +1,45 @@
+package app.photofox.vipsffm
+
+import app.photofox.vipsffm.enums.VipsAccess
+import io.konifer.ImageFactory
+import io.konifer.TestImageType
+import io.konifer.common.image.ImageFormat
+import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_ACCESS
+import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_N_PAGES
+import io.konifer.infrastructure.vips.VipsOptionNames.OPTION_PAGE_HEIGHT
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class VipsImageCopyMemoryTest {
+    @Test
+    fun `materializes a sequential multipage image and preserves its header`() {
+        val encoded =
+            ImageFactory
+                .testImage(
+                    format = ImageFormat.GIF,
+                    type = TestImageType.KERMIT,
+                ).bytes
+
+        Vips.run { arena ->
+            val source =
+                VImage.newFromBytes(
+                    arena,
+                    encoded,
+                    VipsOption.Int("n", -1),
+                    VipsOption.Enum(OPTION_ACCESS, VipsAccess.ACCESS_SEQUENTIAL),
+                )
+
+            val copied = VipsImageCopyMemory.copyMemory(arena, source)
+
+            copied.width shouldBe source.width
+            copied.height shouldBe source.height
+            copied.getInt(OPTION_N_PAGES) shouldBe source.getInt(OPTION_N_PAGES)
+            copied.getInt(OPTION_PAGE_HEIGHT) shouldBe source.getInt(OPTION_PAGE_HEIGHT)
+
+            // Demand the bottom before the top to verify the copy is no longer
+            // constrained by the sequential loader's read order.
+            copied.extractArea(0, copied.height - 1, copied.width, 1).writeToMemory()
+            copied.extractArea(0, 0, copied.width, 1).writeToMemory()
+        }
+    }
+}

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/pipeline/VipsPipelineTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/pipeline/VipsPipelineTest.kt
@@ -5,7 +5,9 @@ import io.konifer.common.image.ImageFormat
 import io.konifer.domain.image.ColorSpace
 import io.konifer.domain.variant.Transformation
 import io.konifer.infrastructure.vips.decode.DecodedVipsImage
-import io.konifer.infrastructure.vips.transformer.AlphaState
+import io.konifer.infrastructure.vips.transformer.AlphaRequirement
+import io.konifer.infrastructure.vips.transformer.PixelAccess
+import io.konifer.infrastructure.vips.transformer.TransformationDecision
 import io.konifer.infrastructure.vips.transformer.VipsTransformer
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
@@ -87,7 +89,7 @@ class VipsPipelineTest {
             source = source,
             output = transformedSource1,
             name = "transformation 1",
-            alphaStateRequired = AlphaState.PREMULTIPLIED,
+            alphaStateRequired = AlphaRequirement.PREMULTIPLIED,
         )
         mockRequiredTransformation(
             mock = transformer2,
@@ -95,7 +97,7 @@ class VipsPipelineTest {
             source = transformedSource1,
             output = transformedSource2,
             name = "transformation 2",
-            alphaStateRequired = AlphaState.PREMULTIPLIED,
+            alphaStateRequired = AlphaRequirement.PREMULTIPLIED,
         )
 
         val result =
@@ -138,7 +140,7 @@ class VipsPipelineTest {
             source = source,
             output = transformedSource1,
             name = "transformation 1",
-            alphaStateRequired = AlphaState.PREMULTIPLIED,
+            alphaStateRequired = AlphaRequirement.PREMULTIPLIED,
         )
         mockRequiredTransformation(
             mock = transformer2,
@@ -146,7 +148,7 @@ class VipsPipelineTest {
             source = transformedSource1,
             output = transformedSource2,
             name = "transformation 2",
-            alphaStateRequired = AlphaState.UN_PREMULTIPLIED,
+            alphaStateRequired = AlphaRequirement.UN_PREMULTIPLIED,
         )
 
         val result =
@@ -188,7 +190,7 @@ class VipsPipelineTest {
             source = source,
             output = transformedSource1,
             name = "transformation 1",
-            alphaStateRequired = AlphaState.PREMULTIPLIED,
+            alphaStateRequired = AlphaRequirement.PREMULTIPLIED,
         )
         mockRequiredTransformation(
             mock = transformer2,
@@ -196,7 +198,7 @@ class VipsPipelineTest {
             source = transformedSource1,
             output = transformedSource2,
             name = "transformation 2",
-            alphaStateRequired = AlphaState.PREMULTIPLIED,
+            alphaStateRequired = AlphaRequirement.PREMULTIPLIED,
         )
 
         val result =
@@ -287,7 +289,7 @@ class VipsPipelineTest {
         result.requiresLqipRegeneration shouldBe true
         result.appliedTransformations shouldBe listOf(appliedTransformation)
         verify(exactly = 0) {
-            transformer.requiresTransformation(any(), any(), any(), any())
+            transformer.decide(any())
             transformer.transform(any(), any(), any())
         }
     }
@@ -309,7 +311,7 @@ class VipsPipelineTest {
             output = transformedSource1,
             name = "transformation 1",
             exceptionToThrow = exceptionToThrow,
-            alphaStateRequired = AlphaState.PREMULTIPLIED,
+            alphaStateRequired = AlphaRequirement.PREMULTIPLIED,
         )
         mockRequiredTransformation(
             mock = transformer2,
@@ -392,7 +394,7 @@ class VipsPipelineTest {
         source: VImage,
         output: VImage,
         name: String,
-        alphaStateRequired: AlphaState = AlphaState.UN_PREMULTIPLIED,
+        alphaStateRequired: AlphaRequirement = AlphaRequirement.UN_PREMULTIPLIED,
         exceptionToThrow: Throwable? = null,
         requireLqipRegeneration: Boolean = true,
     ) {
@@ -419,15 +421,19 @@ class VipsPipelineTest {
         }
 
         every {
-            mock.requiresTransformation(
-                arena = arena,
-                source = source,
-                transformation = transformation,
-                appliedTransformations = any(),
+            mock.decide(
+                match {
+                    it.arena == arena &&
+                        it.source == source &&
+                        it.transformation == transformation
+                },
             )
-        } returns true
+        } returns
+            TransformationDecision.Apply(
+                requiredAlpha = alphaStateRequired,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
         every { mock.name } returns name
-        every { mock.requiresAlphaState } returns alphaStateRequired
     }
 
     private fun mockUnRequiredTransformation(
@@ -437,13 +443,14 @@ class VipsPipelineTest {
         name: String,
     ) {
         every {
-            mock.requiresTransformation(
-                arena = arena,
-                source = source,
-                transformation = transformation,
-                appliedTransformations = any(),
+            mock.decide(
+                match {
+                    it.arena == arena &&
+                        it.source == source &&
+                        it.transformation == transformation
+                },
             )
-        } returns false
+        } returns TransformationDecision.Skip
         every {
             mock.name
         } returns name

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/AutoRotateTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/AutoRotateTest.kt
@@ -1,0 +1,61 @@
+package io.konifer.infrastructure.vips.transformer
+
+import app.photofox.vipsffm.VImage
+import io.konifer.common.image.ImageFormat
+import io.konifer.common.image.Rotate
+import io.konifer.domain.image.ColorSpace
+import io.konifer.domain.variant.Transformation
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import java.lang.foreign.Arena
+
+class AutoRotateTest {
+    private val arena = mockk<Arena>()
+    private val source = mockk<VImage>()
+
+    @Test
+    fun `skips transformations that are not auto-rotation`() {
+        AutoRotate.decide(context(rotate = Rotate.NINETY, isAutoRotate = false)) shouldBe TransformationDecision.Skip
+    }
+
+    @Test
+    fun `auto-rotation without vertical reordering remains sequential`() {
+        AutoRotate.decide(context(rotate = Rotate.ZERO, isAutoRotate = true)) shouldBe
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.EITHER,
+                requiredPixelAccess = PixelAccess.SEQUENTIAL,
+            )
+    }
+
+    @ParameterizedTest
+    @EnumSource(Rotate::class, mode = EnumSource.Mode.EXCLUDE, names = ["ZERO"])
+    fun `auto-rotation with vertical reordering requires random access`(rotate: Rotate) {
+        AutoRotate.decide(context(rotate = rotate, isAutoRotate = true)) shouldBe
+            TransformationDecision.Apply(
+                requiredAlpha = AlphaRequirement.EITHER,
+                requiredPixelAccess = PixelAccess.RANDOM,
+            )
+    }
+
+    private fun context(
+        rotate: Rotate,
+        isAutoRotate: Boolean,
+    ): TransformationContext =
+        TransformationContext(
+            arena = arena,
+            source = source,
+            transformation =
+                Transformation(
+                    width = 10,
+                    height = 10,
+                    format = ImageFormat.PNG,
+                    rotate = rotate,
+                    colorSpace = ColorSpace.SRGB,
+                    isAutoRotate = isAutoRotate,
+                ),
+            appliedTransformations = emptyList(),
+        )
+}

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/ColorFilterTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/ColorFilterTest.kt
@@ -369,18 +369,20 @@ class ColorFilterTest {
     }
 
     @Nested
-    inner class RequiresTransformationTests {
+    inner class DecisionTests {
         @Test
         fun `does not require transformation if filter is NONE`() {
             val image = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
 
             Vips.run { arena ->
-                ColorFilter.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, image),
-                    transformation = colorFilterTransformation(Filter.NONE),
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                ColorFilter.decide(
+                    TransformationContext(
+                        arena,
+                        VImage.newFromBytes(arena, image),
+                        colorFilterTransformation(Filter.NONE),
+                        emptyList(),
+                    ),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -390,12 +392,18 @@ class ColorFilterTest {
             val image = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
 
             Vips.run { arena ->
-                ColorFilter.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, image),
-                    transformation = colorFilterTransformation(filter),
-                    appliedTransformations = emptyList(),
-                ) shouldBe true
+                ColorFilter.decide(
+                    TransformationContext(
+                        arena,
+                        VImage.newFromBytes(arena, image),
+                        colorFilterTransformation(filter),
+                        emptyList(),
+                    ),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
     }

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/CropFirstPageTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/CropFirstPageTest.kt
@@ -67,7 +67,7 @@ class CropFirstPageTest {
     }
 
     @Nested
-    inner class RequiresTransformationTests {
+    inner class DecisionTests {
         @ParameterizedTest
         @MethodSource("io.konifer.ImageTestSources#notSupportsPagedSource")
         fun `images that do not support multi-page are skipped`(format: ImageFormat) {
@@ -90,7 +90,9 @@ class CropFirstPageTest {
                         format = format,
                         colorSpace = ColorSpace.SRGB,
                     )
-                CropFirstPage.requiresTransformation(arena, source, transformation, emptyList()) shouldBe false
+                CropFirstPage.decide(
+                    TransformationContext(arena, source, transformation, emptyList()),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -116,7 +118,9 @@ class CropFirstPageTest {
                         format = format,
                         colorSpace = ColorSpace.SRGB,
                     )
-                CropFirstPage.requiresTransformation(arena, source, transformation, emptyList()) shouldBe false
+                CropFirstPage.decide(
+                    TransformationContext(arena, source, transformation, emptyList()),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -142,7 +146,13 @@ class CropFirstPageTest {
                         format = format,
                         colorSpace = ColorSpace.SRGB,
                     )
-                CropFirstPage.requiresTransformation(arena, source, transformation, emptyList()) shouldBe true
+                CropFirstPage.decide(
+                    TransformationContext(arena, source, transformation, emptyList()),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.EITHER,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
     }

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/ForceRgbBandsTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/ForceRgbBandsTest.kt
@@ -59,30 +59,32 @@ class ForceRgbBandsTest {
     }
 
     @Nested
-    inner class RequiresTransformationTests {
+    inner class DecisionTests {
         @Test
         fun `requires transformation when image has alpha`() {
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, alphaPng())
 
-                ForceRgbBands.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation = transformation,
-                    appliedTransformations = emptyList(),
-                ) shouldBe true
+                ForceRgbBands.decide(
+                    TransformationContext(arena, source, transformation, emptyList()),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
 
         @Test
         fun `requires transformation when image is not three bands`() {
             Vips.run { arena ->
-                ForceRgbBands.requiresTransformation(
-                    arena = arena,
-                    source = VImage.black(arena, 2, 2),
-                    transformation = transformation,
-                    appliedTransformations = emptyList(),
-                ) shouldBe true
+                ForceRgbBands.decide(
+                    TransformationContext(arena, VImage.black(arena, 2, 2), transformation, emptyList()),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
 
@@ -98,19 +100,11 @@ class ForceRgbBandsTest {
                         transformation = transformation,
                     )
 
-                ForceRgbBands.requiresTransformation(
-                    arena = arena,
-                    source = transformed.processed,
-                    transformation = transformation,
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                ForceRgbBands.decide(
+                    TransformationContext(arena, transformed.processed, transformation, emptyList()),
+                ) shouldBe TransformationDecision.Skip
             }
         }
-    }
-
-    @Test
-    fun `requires un-premultiplied alpha`() {
-        ForceRgbBands.requiresAlphaState shouldBe AlphaState.UN_PREMULTIPLIED
     }
 
     private companion object {

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/GaussianBlurTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/GaussianBlurTest.kt
@@ -164,18 +164,15 @@ class GaussianBlurTest {
     }
 
     @Nested
-    inner class RequiresTransformationTests {
+    inner class DecisionTests {
         @Test
         fun `does not require transformation if blur is 0`() {
             val image = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
 
             Vips.run { arena ->
-                GaussianBlur.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, image),
-                    transformation = blurTransformation(0),
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                GaussianBlur.decide(
+                    TransformationContext(arena, VImage.newFromBytes(arena, image), blurTransformation(0), emptyList()),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -184,12 +181,13 @@ class GaussianBlurTest {
             val image = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
 
             Vips.run { arena ->
-                GaussianBlur.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, image),
-                    transformation = blurTransformation(1),
-                    appliedTransformations = emptyList(),
-                ) shouldBe true
+                GaussianBlur.decide(
+                    TransformationContext(arena, VImage.newFromBytes(arena, image), blurTransformation(1), emptyList()),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.PREMULTIPLIED,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
     }

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/PadTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/PadTest.kt
@@ -313,17 +313,19 @@ class PadTest {
     }
 
     @Nested
-    inner class RequiresTransformationTests {
+    inner class DecisionTests {
         @Test
         fun `does not require transformation if if pad is 0`() {
             val imageBytes = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
             Vips.run { arena ->
-                Pad.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, imageBytes),
-                    transformation = padTransformation(0, listOf(200, 45, 0)),
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                Pad.decide(
+                    TransformationContext(
+                        arena,
+                        VImage.newFromBytes(arena, imageBytes),
+                        padTransformation(0, listOf(200, 45, 0)),
+                        emptyList(),
+                    ),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -331,12 +333,14 @@ class PadTest {
         fun `does not require transformation if if background is empty`() {
             val imageBytes = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
             Vips.run { arena ->
-                Pad.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, imageBytes),
-                    transformation = padTransformation(10, emptyList()),
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                Pad.decide(
+                    TransformationContext(
+                        arena,
+                        VImage.newFromBytes(arena, imageBytes),
+                        padTransformation(10, emptyList()),
+                        emptyList(),
+                    ),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -344,12 +348,18 @@ class PadTest {
         fun `requires transformation if if pad is greater than 0 and background is not empty`() {
             val imageBytes = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
             Vips.run { arena ->
-                Pad.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, imageBytes),
-                    transformation = padTransformation(1, listOf(200, 45, 0)),
-                    appliedTransformations = emptyList(),
-                ) shouldBe true
+                Pad.decide(
+                    TransformationContext(
+                        arena,
+                        VImage.newFromBytes(arena, imageBytes),
+                        padTransformation(1, listOf(200, 45, 0)),
+                        emptyList(),
+                    ),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
     }

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/ResizeTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/ResizeTest.kt
@@ -641,7 +641,7 @@ class ResizeTest {
     }
 
     @Nested
-    inner class RequiresTransformationTests {
+    inner class DecisionTests {
         @Test
         fun `transformation not required if source dimensions match transformation dimensions`() {
             val image =
@@ -650,16 +650,18 @@ class ResizeTest {
                 }
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
-                Resize.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation =
-                        resizeTransformation(
-                            width = source.width,
-                            height = source.height,
-                        ),
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                Resize.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = source,
+                        transformation =
+                            resizeTransformation(
+                                width = source.width,
+                                height = source.height,
+                            ),
+                        appliedTransformations = emptyList(),
+                    ),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -671,16 +673,18 @@ class ResizeTest {
                 }
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
-                Resize.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation =
-                        resizeTransformation(
-                            width = source.width + 1,
-                            height = source.height,
-                        ),
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                Resize.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = source,
+                        transformation =
+                            resizeTransformation(
+                                width = source.width + 1,
+                                height = source.height,
+                            ),
+                        appliedTransformations = emptyList(),
+                    ),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -692,17 +696,19 @@ class ResizeTest {
                 }
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
-                Resize.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation =
-                        resizeTransformation(
-                            width = source.width * 2,
-                            height = source.height * 2,
-                            upscale = false,
-                        ),
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                Resize.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = source,
+                        transformation =
+                            resizeTransformation(
+                                width = source.width * 2,
+                                height = source.height * 2,
+                                upscale = false,
+                            ),
+                        appliedTransformations = emptyList(),
+                    ),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -714,16 +720,48 @@ class ResizeTest {
                 }
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
-                Resize.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation =
-                        resizeTransformation(
-                            width = source.width - 1,
-                            height = source.height,
-                        ),
-                    appliedTransformations = emptyList(),
-                ) shouldBe true
+                Resize.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = source,
+                        transformation =
+                            resizeTransformation(
+                                width = source.width - 1,
+                                height = source.height,
+                            ),
+                        appliedTransformations = emptyList(),
+                    ),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
+            }
+        }
+
+        @Test
+        fun `crop requires random pixel access`() {
+            val image = javaClass.getResourceAsStream("/images/joshua-tree/joshua-tree.png")!!.readBytes()
+            Vips.run { arena ->
+                val source = VImage.newFromBytes(arena, image)
+
+                Resize.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = source,
+                        transformation =
+                            resizeTransformation(
+                                width = source.width - 1,
+                                height = source.height - 1,
+                                fit = Fit.CROP,
+                            ),
+                        appliedTransformations = emptyList(),
+                    ),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                        requiredPixelAccess = PixelAccess.RANDOM,
+                    )
             }
         }
 

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/RotateFlipTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/RotateFlipTest.kt
@@ -95,26 +95,28 @@ class RotateFlipTest {
     }
 
     @Nested
-    inner class RequiresTransformationTests {
+    inner class DecisionTests {
         @Test
         fun `does not require transformation if rotate is zero and no horizontal flip`() {
             val image = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
 
             Vips.run { arena ->
-                RotateFlip.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, image),
-                    transformation =
-                        Transformation(
-                            width = 10,
-                            height = 10,
-                            format = ImageFormat.PNG,
-                            rotate = Rotate.ZERO,
-                            horizontalFlip = false,
-                            colorSpace = ColorSpace.SRGB,
-                        ),
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                RotateFlip.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = VImage.newFromBytes(arena, image),
+                        transformation =
+                            Transformation(
+                                width = 10,
+                                height = 10,
+                                format = ImageFormat.PNG,
+                                rotate = Rotate.ZERO,
+                                horizontalFlip = false,
+                                colorSpace = ColorSpace.SRGB,
+                            ),
+                        appliedTransformations = emptyList(),
+                    ),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -124,20 +126,26 @@ class RotateFlipTest {
             val image = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
 
             Vips.run { arena ->
-                RotateFlip.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, image),
-                    transformation =
-                        Transformation(
-                            width = 10,
-                            height = 10,
-                            format = ImageFormat.PNG,
-                            rotate = rotate,
-                            horizontalFlip = false,
-                            colorSpace = ColorSpace.SRGB,
-                        ),
-                    appliedTransformations = emptyList(),
-                ) shouldBe true
+                RotateFlip.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = VImage.newFromBytes(arena, image),
+                        transformation =
+                            Transformation(
+                                width = 10,
+                                height = 10,
+                                format = ImageFormat.PNG,
+                                rotate = rotate,
+                                horizontalFlip = false,
+                                colorSpace = ColorSpace.SRGB,
+                            ),
+                        appliedTransformations = emptyList(),
+                    ),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.EITHER,
+                        requiredPixelAccess = PixelAccess.RANDOM,
+                    )
             }
         }
 
@@ -146,20 +154,26 @@ class RotateFlipTest {
             val image = javaClass.getResourceAsStream("/images/apollo-11.jpeg")!!.readAllBytes()
 
             Vips.run { arena ->
-                RotateFlip.requiresTransformation(
-                    arena = arena,
-                    source = VImage.newFromBytes(arena, image),
-                    transformation =
-                        Transformation(
-                            width = 10,
-                            height = 10,
-                            format = ImageFormat.PNG,
-                            rotate = Rotate.ZERO,
-                            horizontalFlip = true,
-                            colorSpace = ColorSpace.SRGB,
-                        ),
-                    appliedTransformations = emptyList(),
-                ) shouldBe true
+                RotateFlip.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = VImage.newFromBytes(arena, image),
+                        transformation =
+                            Transformation(
+                                width = 10,
+                                height = 10,
+                                format = ImageFormat.PNG,
+                                rotate = Rotate.ZERO,
+                                horizontalFlip = true,
+                                colorSpace = ColorSpace.SRGB,
+                            ),
+                        appliedTransformations = emptyList(),
+                    ),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.EITHER,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
     }

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/StripMetadataTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/StripMetadataTest.kt
@@ -17,6 +17,53 @@ import org.junit.jupiter.api.Test
 
 class StripMetadataTest {
     @Nested
+    inner class DecisionTests {
+        @Test
+        fun `applies when requested metadata exists`() {
+            val image = javaClass.getResourceAsStream("/images/metadata/exif-xmp-iptc.jpg")!!.readBytes()
+            Vips.run { arena ->
+                val source = VImage.newFromBytes(arena, image)
+                val transformation =
+                    Transformation(
+                        width = source.width,
+                        height = source.height,
+                        format = ImageFormat.JPEG,
+                        metadata = MetadataTransformation(strip = setOf(MetadataType.EXIF)),
+                        colorSpace = ColorSpace.SRGB,
+                    )
+
+                StripMetadata.decide(
+                    TransformationContext(arena, source, transformation, emptyList()),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.EITHER,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
+            }
+        }
+
+        @Test
+        fun `skips when no metadata is requested`() {
+            val image = javaClass.getResourceAsStream("/images/metadata/exif-xmp-iptc.jpg")!!.readBytes()
+            Vips.run { arena ->
+                val source = VImage.newFromBytes(arena, image)
+                val transformation =
+                    Transformation(
+                        width = source.width,
+                        height = source.height,
+                        format = ImageFormat.JPEG,
+                        metadata = MetadataTransformation(strip = emptySet()),
+                        colorSpace = ColorSpace.SRGB,
+                    )
+
+                StripMetadata.decide(
+                    TransformationContext(arena, source, transformation, emptyList()),
+                ) shouldBe TransformationDecision.Skip
+            }
+        }
+    }
+
+    @Nested
     inner class TransformTests {
         @Test
         fun `removes exif tags if exif is to be stripped`() {

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/StripThumbnailExifTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/StripThumbnailExifTest.kt
@@ -74,7 +74,7 @@ class StripThumbnailExifTest {
     }
 
     @Nested
-    inner class RequiresTransformationTests {
+    inner class DecisionTests {
         @Test
         fun `requires transformation if transformations have been applied`() {
             val image =
@@ -84,18 +84,24 @@ class StripThumbnailExifTest {
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
 
-                StripThumbnailExif.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation = Transformation.ORIGINAL_VARIANT,
-                    appliedTransformations =
-                        listOf(
-                            AppliedTransformation(
-                                name = "something",
-                                exceptionMessage = null,
+                StripThumbnailExif.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = source,
+                        transformation = Transformation.ORIGINAL_VARIANT,
+                        appliedTransformations =
+                            listOf(
+                                AppliedTransformation(
+                                    name = "something",
+                                    exceptionMessage = null,
+                                ),
                             ),
-                        ),
-                ) shouldBe true
+                    ),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.EITHER,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
 
@@ -108,12 +114,9 @@ class StripThumbnailExifTest {
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
 
-                StripThumbnailExif.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation = Transformation.ORIGINAL_VARIANT,
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                StripThumbnailExif.decide(
+                    TransformationContext(arena, source, Transformation.ORIGINAL_VARIANT, emptyList()),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -126,18 +129,20 @@ class StripThumbnailExifTest {
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
 
-                StripThumbnailExif.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation = Transformation.ORIGINAL_VARIANT,
-                    appliedTransformations =
-                        listOf(
-                            AppliedTransformation(
-                                name = StripMetadata.name,
-                                exceptionMessage = null,
+                StripThumbnailExif.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = source,
+                        transformation = Transformation.ORIGINAL_VARIANT,
+                        appliedTransformations =
+                            listOf(
+                                AppliedTransformation(
+                                    name = StripMetadata.name,
+                                    exceptionMessage = null,
+                                ),
                             ),
-                        ),
-                ) shouldBe false
+                    ),
+                ) shouldBe TransformationDecision.Skip
             }
         }
 
@@ -150,22 +155,28 @@ class StripThumbnailExifTest {
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
 
-                StripThumbnailExif.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation = Transformation.ORIGINAL_VARIANT,
-                    appliedTransformations =
-                        listOf(
-                            AppliedTransformation(
-                                name = StripMetadata.name,
-                                exceptionMessage = null,
+                StripThumbnailExif.decide(
+                    TransformationContext(
+                        arena = arena,
+                        source = source,
+                        transformation = Transformation.ORIGINAL_VARIANT,
+                        appliedTransformations =
+                            listOf(
+                                AppliedTransformation(
+                                    name = StripMetadata.name,
+                                    exceptionMessage = null,
+                                ),
+                                AppliedTransformation(
+                                    name = Resize.name,
+                                    exceptionMessage = null,
+                                ),
                             ),
-                            AppliedTransformation(
-                                name = Resize.name,
-                                exceptionMessage = null,
-                            ),
-                        ),
-                ) shouldBe true
+                    ),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.EITHER,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
     }

--- a/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/TransformColorSpaceTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/vips/transformer/TransformColorSpaceTest.kt
@@ -10,7 +10,6 @@ import io.konifer.infrastructure.vips.ImageColorSpaceExtractor
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -101,7 +100,7 @@ class TransformColorSpaceTest {
     }
 
     @Nested
-    inner class RequiresTransformationTests {
+    inner class DecisionTests {
         @ParameterizedTest
         @ValueSource(strings = ["srgb", "p3", "grayscale"])
         fun `requires transformation if color space is different from interpreted color space`(colorSpaceName: String) {
@@ -119,12 +118,13 @@ class TransformColorSpaceTest {
 
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
-                TransformColorSpace.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation = transformation,
-                    appliedTransformations = emptyList(),
-                ) shouldBe true
+                TransformColorSpace.decide(
+                    TransformationContext(arena, source, transformation, emptyList()),
+                ) shouldBe
+                    TransformationDecision.Apply(
+                        requiredAlpha = AlphaRequirement.UN_PREMULTIPLIED,
+                        requiredPixelAccess = PixelAccess.SEQUENTIAL,
+                    )
             }
         }
 
@@ -148,18 +148,10 @@ class TransformColorSpaceTest {
 
             Vips.run { arena ->
                 val source = VImage.newFromBytes(arena, image)
-                TransformColorSpace.requiresTransformation(
-                    arena = arena,
-                    source = source,
-                    transformation = transformation,
-                    appliedTransformations = emptyList(),
-                ) shouldBe false
+                TransformColorSpace.decide(
+                    TransformationContext(arena, source, transformation, emptyList()),
+                ) shouldBe TransformationDecision.Skip
             }
         }
-    }
-
-    @Test
-    fun `requires un-premultiplied alpha`() {
-        TransformColorSpace.requiresAlphaState shouldBe AlphaState.UN_PREMULTIPLIED
     }
 }


### PR DESCRIPTION
Basically, keep the source sequentially read as much as possible and only when necessary, convert to random access.