### PR TITLE
[Breaking] Rename max-height/width to clamp-height/width

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ paths {
       eager-variants = [thumbnail]
       preprocessing {
         enabled = true
-        max-width = 1024
-        max-height = 1024
+        clamp-width = 1024
+        clamp-height = 1024
         fit = fit
       }
     }

--- a/service/src/functionalTest/kotlin/io/konifer/asset/variant/ImagePreProcessingTest.kt
+++ b/service/src/functionalTest/kotlin/io/konifer/asset/variant/ImagePreProcessingTest.kt
@@ -52,7 +52,7 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
                 transform {
                   preprocessing {
                     enabled = true
-                    max-width = 100
+                    clamp-width = 100
                   }
                 }
               }
@@ -95,7 +95,7 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
                 transform {
                   preprocessing {
                     enabled = true
-                    max-height = 50
+                    clamp-height = 50
                   }
                 }
               }
@@ -143,8 +143,8 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
             transform {
               preprocessing {
                 enabled = true
-                ${maxHeight?.let { "max-height = $it" } ?: ""}
-                ${maxWidth?.let { "max-width = $it" } ?: ""}
+                ${maxHeight?.let { "clamp-height = $it" } ?: ""}
+                ${maxWidth?.let { "clamp-width = $it" } ?: ""}
               }
             }
           }
@@ -231,7 +231,7 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
                   preprocessing {
                     enabled = true
                     format = jpg
-                    max-height = 55
+                    clamp-height = 55
                   }  
                 }
               }
@@ -239,7 +239,7 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
                 transform {
                   preprocessing {
                     format = webp
-                    max-height = 50
+                    clamp-height = 50
                   }
                 }
               }
@@ -283,7 +283,7 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
                   preprocessing {
                     enabled = false
                     format = jpg
-                    max-height = 55
+                    clamp-height = 55
                   }
                 }
               }
@@ -322,7 +322,7 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
                   preprocessing {
                     enabled = false
                     format = jpg
-                    max-height = 55
+                    clamp-height = 55
                   }
                 }
               }
@@ -330,7 +330,7 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
                 transform {
                   preprocessing {
                     format = webp
-                    max-height = 50
+                    clamp-height = 50
                   }
                 }
               }
@@ -368,7 +368,7 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
                 transform {
                   preprocessing {
                     enabled = true
-                    max-height = 50
+                    clamp-height = 50
                   }
                 }
               }
@@ -446,8 +446,8 @@ class ImagePreProcessingTest : BaseFunctionalTest() {
                 transform {
                   preprocessing {
                     enabled = true
-                    max-width = 3000
-                      format = png
+                    clamp-width = 3000
+                    format = png
                   }
                 }
               }

--- a/service/src/main/kotlin/io/konifer/domain/transformation/PreProcessingProperties.kt
+++ b/service/src/main/kotlin/io/konifer/domain/transformation/PreProcessingProperties.kt
@@ -17,10 +17,10 @@ import kotlinx.serialization.Serializable
 data class PreProcessingProperties(
     @SerialName(ENABLED)
     val enabled: Boolean = false,
-    @SerialName(PreProcessingPropertyKeys.MAX_WIDTH)
-    val maxWidth: Int? = null,
-    @SerialName(PreProcessingPropertyKeys.MAX_HEIGHT)
-    val maxHeight: Int? = null,
+    @SerialName(PreProcessingPropertyKeys.CLAMP_WIDTH)
+    val clampWidth: Int? = null,
+    @SerialName(PreProcessingPropertyKeys.CLAMP_HEIGHT)
+    val clampHeight: Int? = null,
     @SerialName(ManipulationParameters.WIDTH)
     val width: Int? = null,
     @SerialName(ManipulationParameters.HEIGHT)
@@ -61,14 +61,14 @@ data class PreProcessingProperties(
 
     private fun toRequestedImageTransformation(): RequestedTransformation =
         RequestedTransformation(
-            width = (width ?: maxWidth)?.toDimension(),
-            height = (height ?: maxHeight)?.toDimension(),
+            width = (width ?: clampWidth)?.toDimension(),
+            height = (height ?: clampHeight)?.toDimension(),
             format = format,
             fit = fit,
             gravity = gravity,
             rotate = rotate,
             flip = flip,
-            canUpscale = maxWidth == null && maxHeight == null,
+            canUpscale = clampWidth == null && clampHeight == null,
             filter = filter,
             blur = blur?.toBlur(),
             quality = quality?.toQuality(),

--- a/service/src/main/kotlin/io/konifer/infrastructure/property/ConfigurationPropertyKeys.kt
+++ b/service/src/main/kotlin/io/konifer/infrastructure/property/ConfigurationPropertyKeys.kt
@@ -114,8 +114,8 @@ object ConfigurationPropertyKeys {
 
             object PreProcessingPropertyKeys {
                 const val ENABLED = "enabled"
-                const val MAX_HEIGHT = "max-height"
-                const val MAX_WIDTH = "max-width"
+                const val CLAMP_HEIGHT = "clamp-height"
+                const val CLAMP_WIDTH = "clamp-width"
             }
 
             object OnDemandVariantsPropertyKeys {

--- a/service/src/test/kotlin/io/konifer/domain/transformation/PreProcessingPropertiesTest.kt
+++ b/service/src/test/kotlin/io/konifer/domain/transformation/PreProcessingPropertiesTest.kt
@@ -91,8 +91,8 @@ class PreProcessingPropertiesTest {
     fun `PreProcessingProperties default contains default values`() {
         val default = PreProcessingProperties.default
         default.format shouldBe null
-        default.maxWidth shouldBe null
-        default.maxHeight shouldBe null
+        default.clampWidth shouldBe null
+        default.clampHeight shouldBe null
         default.width shouldBe null
         default.height shouldBe null
         default.rotate shouldBe Rotate.default

--- a/service/src/test/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepositoryTest.kt
+++ b/service/src/test/kotlin/io/konifer/infrastructure/path/TriePathConfigurationRepositoryTest.kt
@@ -192,7 +192,7 @@ class TriePathConfigurationRepositoryTest {
                 ]
                 transform {
                   preprocessing = {
-                    max-height = 10
+                    clamp-height = 10
                   }
                 }
               }
@@ -200,7 +200,7 @@ class TriePathConfigurationRepositoryTest {
                 allowed-content-types = [ ]
                 transform {
                   preprocessing = {
-                    max-width = 10
+                    clamp-width = 10
                   }
                 }
               }
@@ -213,8 +213,8 @@ class TriePathConfigurationRepositoryTest {
             )
         val pathConfiguration = pathConfigurationRepository.fetch("/users/123/profile")
         pathConfiguration.allowedContentTypes shouldBe listOf()
-        pathConfiguration.transform.preProcessing.maxWidth shouldBe 10
-        pathConfiguration.transform.preProcessing.maxHeight shouldBe 10
+        pathConfiguration.transform.preProcessing.clampWidth shouldBe 10
+        pathConfiguration.transform.preProcessing.clampHeight shouldBe 10
     }
 
     @Test
@@ -285,7 +285,7 @@ class TriePathConfigurationRepositoryTest {
                 ]
                 transform {
                   preprocessing = {
-                    max-height = 10
+                    clamp-height = 10
                   }
                 }
               }
@@ -293,7 +293,7 @@ class TriePathConfigurationRepositoryTest {
                 allowed-content-types = [ ]
                 transform {
                   preprocessing = {
-                    max-width = 10
+                    clamp-width = 10
                   }
                 }
               }
@@ -306,8 +306,8 @@ class TriePathConfigurationRepositoryTest {
             )
         val pathConfiguration = pathConfigurationRepository.fetch("/users/123/profile")
         pathConfiguration.allowedContentTypes shouldBe listOf()
-        pathConfiguration.transform.preProcessing.maxWidth shouldBe 10
-        pathConfiguration.transform.preProcessing.maxHeight shouldBe 10
+        pathConfiguration.transform.preProcessing.clampWidth shouldBe 10
+        pathConfiguration.transform.preProcessing.clampHeight shouldBe 10
     }
 
     @Test

--- a/service/src/testFixtures/kotlin/io/konifer/ImageUtils.kt
+++ b/service/src/testFixtures/kotlin/io/konifer/ImageUtils.kt
@@ -253,8 +253,8 @@ fun createPreProcessingProperties(
 ): PreProcessingProperties =
     PreProcessingProperties(
         enabled = enabled,
-        maxWidth = maxWidth,
-        maxHeight = maxHeight,
+        clampWidth = maxWidth,
+        clampHeight = maxHeight,
         width = width,
         height = height,
         format = format,


### PR DESCRIPTION
This will help with ambiguity around `limits.max-height` and preprocessing.max-height` (and width). It's also a better descriptor of what these settings do.